### PR TITLE
Enable uploading of the driver to PyPI

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -22,7 +22,6 @@ Introduction
 
 CircuitPython `displayio` driver for SSD1680-based ePaper displays
 
-
 Dependencies
 =============
 This driver depends on:
@@ -42,6 +41,31 @@ or individual libraries can be installed using
 * Adafruit 2.13" HD Tri-Color eInk / ePaper Display FeatherWing - 250x122 RW Panel with SSD1680
 
 `Purchase the FeatherWing from the Adafruit shop <http://www.adafruit.com/products/4814>`_
+
+Installing from PyPI
+=====================
+
+On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
+PyPI <https://pypi.org/project/adafruit-circuitpython-ssd1680/>`_. To install for current user:
+
+.. code-block:: shell
+
+    pip3 install adafruit-circuitpython-ssd1680
+
+To install system-wide (this may be required in some cases):
+
+.. code-block:: shell
+
+    sudo pip3 install adafruit-circuitpython-ssd1680
+
+To install in a virtual environment in your current project:
+
+.. code-block:: shell
+
+    mkdir project-name && cd project-name
+    python3 -m venv .env
+    source .env/bin/activate
+    pip3 install adafruit-circuitpython-ssd1680
 
 Usage Example
 =============
@@ -78,21 +102,22 @@ Usage Example
 
     g = displayio.Group()
 
-    f = open("/display-ruler.bmp", "rb")
-
-    pic = displayio.OnDiskBitmap(f)
     # CircuitPython 6 & 7 compatible
+    f = open("/display-ruler.bmp", "rb")
+    pic = displayio.OnDiskBitmap(f)
     t = displayio.TileGrid(
         pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
     )
-    # CircuitPython 7 compatible only
+
+    # # CircuitPython 7 compatible only
+    # pic = displayio.OnDiskBitmap("/display-ruler.bmp")
     # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
+
     g.append(t)
 
     display.show(g)
 
     display.refresh()
-
     print("refreshed")
 
     time.sleep(120)
@@ -108,5 +133,5 @@ before contributing to help this project stay welcoming.
 Documentation
 =============
 
-For information on building library documentation, please check out
-`this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.
+For information on building library documentation, please check out `this guide
+<https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,57 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+#
+# SPDX-License-Identifier: MIT
+
+"""A setuptools based setup module.
+
+See:
+https://packaging.python.org/en/latest/distributing.html
+https://github.com/pypa/sampleproject
+"""
+
+from setuptools import setup, find_packages
+
+# To use a consistent encoding
+from codecs import open
+from os import path
+
+here = path.abspath(path.dirname(__file__))
+
+# Get the long description from the README file
+with open(path.join(here, "README.rst"), encoding="utf-8") as f:
+    long_description = f.read()
+
+setup(
+    name="adafruit-circuitpython-ssd1680",
+    use_scm_version=True,
+    setup_requires=["setuptools_scm"],
+    description="CircuitPython `displayio` drivers for SSD1680-based ePaper displays",
+    long_description=long_description,
+    long_description_content_type="text/x-rst",
+    # The project's main homepage.
+    url="https://github.com/adafruit/Adafruit_CircuitPython_SSD1680",
+    # Author details
+    author="Adafruit Industries",
+    author_email="circuitpython@adafruit.com",
+    install_requires=["Adafruit-Blinka"],
+    # Choose your license
+    license="MIT",
+    # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+    classifiers=[
+        "Development Status :: 3 - Alpha",
+        "Intended Audience :: Developers",
+        "Topic :: Software Development :: Libraries",
+        "Topic :: System :: Hardware",
+        "License :: OSI Approved :: MIT License",
+        "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.4",
+        "Programming Language :: Python :: 3.5",
+    ],
+    # What does your project relate to?
+    keywords="adafruit blinka circuitpython micropython ssd1680 displayio epd epaper",
+    # You can just specify the packages manually here if your project is
+    # simple. Or you can use find_packages().
+    # TODO: IF LIBRARY FILES ARE A PACKAGE FOLDER,
+    #       CHANGE `py_modules=['...']` TO `packages=['...']`
+    py_modules=["adafruit_ssd1680"],
+)

--- a/setup.py.disabled
+++ b/setup.py.disabled
@@ -1,8 +1,0 @@
-# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
-#
-# SPDX-License-Identifier: MIT
-
-"""
-This library is not deployed to PyPI. It is either a board-specific helper library, or
-does not make sense for use on or is incompatible with single board computers and Linux.
-"""


### PR DESCRIPTION
This allows the driver to used with Blinka
Ref: https://github.com/adafruit/Adafruit_CircuitPython_Bundle/issues/336