### PR TITLE
Fix for issue 15, use the new display.time_to_refresh

### DIFF
--- a/examples/ssd1680_2.13_featherwing.py
+++ b/examples/ssd1680_2.13_featherwing.py
@@ -57,4 +57,14 @@ with open("/display-ruler.bmp", "rb") as f:
 
     print("refreshed")
 
-    time.sleep(120)
+    time.sleep(display.time_to_refresh + 5)
+    # Always refresh a little longer. It's not a problem to refresh
+    # a few seconds more, but it's terrible to refresh too early
+    # (the display will throw an exception when if the refresh
+    # is too soon)
+    print("waited correct time")
+
+
+# Keep the display the same
+while True:
+    time.sleep(10)

--- a/examples/ssd1680_simpletest.py
+++ b/examples/ssd1680_simpletest.py
@@ -64,4 +64,14 @@ with open("/display-ruler.bmp", "rb") as f:
 
     print("refreshed")
 
-    time.sleep(120)
+    time.sleep(display.time_to_refresh + 5)
+    # Always refresh a little longer. It's not a problem to refresh
+    # a few seconds more, but it's terrible to refresh too early
+    # (the display will throw an exception when if the refresh
+    # is too soon)
+    print("waited correct time")
+
+
+# Keep the display the same
+while True:
+    time.sleep(10)


### PR DESCRIPTION
This is a fairly minimal set of changes to switch the timeout value from the old value (hardcoded to be 120, or 2 minutes) to the newer "display.time_to_refresh" which is set to be 180 (3 minutes).

I don't just wait the exact amount of time. My experience with other operating systems is that "sleep" times are often modified: the OS might choose to wake either earlier or later. Later isn't a problem, but earlier is a very bad: presumably the developer is about to call refresh() and that will throw if the time is a little early. Since we have to wait for 180 seconds anyway, five extra seconds shouldn't be a deal breaker.

I also updated the code to have an infinite loop at the end -- otherwise the code will fully exit and the display might be reset (I've seen the display reset several times while doing my testing).