### PR TITLE
Fix typo in FourWire

### DIFF
--- a/adafruit_ssd1680.py
+++ b/adafruit_ssd1680.py
@@ -66,7 +66,7 @@ class SSD1680(displayio.EPaperDisplay):
           Display rotation
     """
 
-    def __init__(self, bus: displayio.Fourwire, **kwargs) -> None:
+    def __init__(self, bus: displayio.FourWire, **kwargs) -> None:
         if "colstart" not in kwargs:
             kwargs["colstart"] = 1
         stop_sequence = bytearray(_STOP_SEQUENCE)


### PR DESCRIPTION
I noticed this when running the driver on the Raspberry Pi, which is less forgiving. I think this may have been a carryover from the SSD1675, which has already been fixed.