### PR TITLE
Fix column offset for ssd1680 instead of ssd1675

### DIFF
--- a/adafruit_ssd1680.py
+++ b/adafruit_ssd1680.py
@@ -68,7 +68,7 @@ class SSD1680(displayio.EPaperDisplay):
 
     def __init__(self, bus: displayio.FourWire, **kwargs) -> None:
         if "colstart" not in kwargs:
-            kwargs["colstart"] = 1
+            kwargs["colstart"] = 8
         stop_sequence = bytearray(_STOP_SEQUENCE)
         try:
             bus.reset()

--- a/examples/ssd1680_2.13_featherwing.py
+++ b/examples/ssd1680_2.13_featherwing.py
@@ -45,9 +45,7 @@ g = displayio.Group()
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
 
-    t = displayio.TileGrid(
-        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
-    )
+    t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
 
     g.append(t)
 

--- a/examples/ssd1680_2.13_tricolor_breakout.py
+++ b/examples/ssd1680_2.13_tricolor_breakout.py
@@ -44,9 +44,7 @@ g = displayio.Group()
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
 
-    t = displayio.TileGrid(
-        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
-    )
+    t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
 
     g.append(t)
 

--- a/examples/ssd1680_simpletest.py
+++ b/examples/ssd1680_simpletest.py
@@ -50,12 +50,7 @@ g = displayio.Group()
 
 with open("/display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
-    # CircuitPython 6 & 7 compatible
-    t = displayio.TileGrid(
-        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
-    )
-    # CircuitPython 7 compatible only
-    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
+    t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)

--- a/examples/ssd1680_simpletest.py
+++ b/examples/ssd1680_simpletest.py
@@ -37,7 +37,7 @@ time.sleep(1)
 # For issues with display not updating top/bottom rows correctly set colstart to 8
 display = adafruit_ssd1680.SSD1680(
     display_bus,
-    colstart=1,
+    colstart=8,
     width=250,
     height=122,
     busy_pin=epd_busy,


### PR DESCRIPTION
#9 changed the column offset from 8 to 1 in order to "fix" #5. However, in hindsight, I realize the user was likely using the incorrect driver (for example SSD1675 displays appear shifted like in #5). I have tested this fix on known SSD1680 tri-color displays as well as SSD1680 monochrome displays and it fixes the shift.