### PR TITLE
Add an example for the 2.13 inch eink bonnet

### DIFF
--- a/examples/ssd1680_2.13_featherwing.py
+++ b/examples/ssd1680_2.13_featherwing.py
@@ -33,7 +33,6 @@ time.sleep(1)
 
 display = adafruit_ssd1680.SSD1680(
     display_bus,
-    colstart=8,
     width=250,
     height=122,
     highlight_color=0xFF0000,

--- a/examples/ssd1680_2.13_mono_eink_bonnet.py
+++ b/examples/ssd1680_2.13_mono_eink_bonnet.py
@@ -1,0 +1,75 @@
+# SPDX-FileCopyrightText: 2017 Scott Shawcroft, written for Adafruit Industries
+# SPDX-FileCopyrightText: Copyright (c) 2021 Melissa LeBlanc-Williams for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+"""Simple test script for 2.13" 250x122 tri-color display.
+Supported products:
+  * Adafruit 2.13" Tri-Color eInk Display Breakout
+    * https://www.adafruit.com/product/4947
+  * Adafruit 2.13" Tri-Color eInk Display FeatherWing
+    * https://www.adafruit.com/product/4814
+  * Adafruit 2.13" Mono eInk Display FeatherWing
+    * https://www.adafruit.com/product/4195
+
+
+"""
+
+import time
+import board
+import displayio
+import adafruit_ssd1680
+
+displayio.release_displays()
+
+# This pinout works on a Metro M4 and may need to be altered for other boards.
+spi = board.SPI()  # Uses SCK and MOSI
+epd_cs = board.CE0
+epd_dc = board.D22
+epd_reset = board.D27  # Set to None for FeatherWing
+epd_busy = board.D17  # Set to None for FeatherWing
+
+display_bus = displayio.FourWire(spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000)
+time.sleep(1)
+
+# For issues with display not updating top/bottom rows correctly set colstart to 8
+display = adafruit_ssd1680.SSD1680(
+    display_bus,
+    colstart=8,
+    width=250,
+    height=122,
+    busy_pin=epd_busy,
+    highlight_color=0xFF0000,
+    rotation=90,
+)
+
+
+g = displayio.Group()
+
+with open("display-ruler.bmp", "rb") as f:
+    pic = displayio.OnDiskBitmap(f)
+    # CircuitPython 6 & 7 compatible
+    t = displayio.TileGrid(
+        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
+    )
+    # CircuitPython 7 compatible only
+    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
+    g.append(t)
+
+    display.show(g)
+
+    display.refresh()
+
+    print("refreshed")
+
+    time.sleep(display.time_to_refresh + 5)
+    # Always refresh a little longer. It's not a problem to refresh
+    # a few seconds more, but it's terrible to refresh too early
+    # (the display will throw an exception when if the refresh
+    # is too soon)
+    print("waited correct time")
+
+
+# Keep the display the same
+while True:
+    time.sleep(10)

--- a/examples/ssd1680_2.13_mono_eink_bonnet.py
+++ b/examples/ssd1680_2.13_mono_eink_bonnet.py
@@ -37,7 +37,6 @@ time.sleep(1)
 # For issues with display not updating top/bottom rows correctly set colstart to 8
 display = adafruit_ssd1680.SSD1680(
     display_bus,
-    colstart=8,
     width=250,
     height=122,
     busy_pin=epd_busy,

--- a/examples/ssd1680_2.13_mono_eink_bonnet.py
+++ b/examples/ssd1680_2.13_mono_eink_bonnet.py
@@ -50,12 +50,7 @@ g = displayio.Group()
 
 with open("display-ruler.bmp", "rb") as f:
     pic = displayio.OnDiskBitmap(f)
-    # CircuitPython 6 & 7 compatible
-    t = displayio.TileGrid(
-        pic, pixel_shader=getattr(pic, "pixel_shader", displayio.ColorConverter())
-    )
-    # CircuitPython 7 compatible only
-    # t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
+    t = displayio.TileGrid(pic, pixel_shader=pic.pixel_shader)
     g.append(t)
 
     display.show(g)

--- a/examples/ssd1680_2.13_mono_eink_bonnet.py
+++ b/examples/ssd1680_2.13_mono_eink_bonnet.py
@@ -29,7 +29,9 @@ epd_dc = board.D22
 epd_reset = board.D27  # Set to None for FeatherWing
 epd_busy = board.D17  # Set to None for FeatherWing
 
-display_bus = displayio.FourWire(spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000)
+display_bus = displayio.FourWire(
+    spi, command=epd_dc, chip_select=epd_cs, reset=epd_reset, baudrate=1000000
+)
 time.sleep(1)
 
 # For issues with display not updating top/bottom rows correctly set colstart to 8

--- a/examples/ssd1680_2.13_tricolor_breakout.py
+++ b/examples/ssd1680_2.13_tricolor_breakout.py
@@ -32,7 +32,6 @@ time.sleep(1)
 
 display = adafruit_ssd1680.SSD1680(
     display_bus,
-    colstart=8,
     width=250,
     height=122,
     highlight_color=0xFF0000,

--- a/examples/ssd1680_four_corners.py
+++ b/examples/ssd1680_four_corners.py
@@ -32,7 +32,6 @@ display_bus = displayio.FourWire(
 )
 display = adafruit_ssd1680.SSD1680(
     display_bus,
-    colstart=8,
     width=250,
     height=122,
     busy_pin=epd_busy,

--- a/examples/ssd1680_simpletest.py
+++ b/examples/ssd1680_simpletest.py
@@ -37,7 +37,6 @@ time.sleep(1)
 # For issues with display not updating top/bottom rows correctly set colstart to 8
 display = adafruit_ssd1680.SSD1680(
     display_bus,
-    colstart=8,
     width=250,
     height=122,
     busy_pin=epd_busy,


### PR DESCRIPTION
With https://github.com/adafruit/Adafruit_Blinka_Displayio/pull/115 enabling using eInks, I have added a bonnet example for the Raspberry Pi.