### PR TITLE
Remove unneeded parameter

### DIFF
--- a/adafruit_ssd1680.py
+++ b/adafruit_ssd1680.py
@@ -100,7 +100,6 @@ class SSD1680(EPaperDisplay):
             busy_state=True,
             write_black_ram_command=0x24,
             write_color_ram_command=0x26,
-            black_bits_inverted=False,
             set_column_window_command=0x44,
             set_row_window_command=0x45,
             set_current_column_command=0x4E,


### PR DESCRIPTION
`black_bits_inverted` defaults to False in the core, so this is redundant.

By removing this line, an override value can be provided via kwargs if the default is incorrect.

For a display where the default value gives white-on-black, such as https://www.adafruit.com/product/4195, passing in `black_bits_inverted=True` to the constructor also provides an easy way to invert the whole display, giving white-on-black.