### PR TITLE
Update README with display column start info

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -92,6 +92,7 @@ Usage Example
     )
     time.sleep(1)
 
+    # For issues with display not updating top/bottom rows correctly set colstart to 8, 0, or -8    
     display = adafruit_ssd1680.SSD1680(
         display_bus,
         width=250,
@@ -99,6 +100,7 @@ Usage Example
         busy_pin=epd_busy,
         highlight_color=0xFF0000,
         rotation=270,
+        colstart=-8,  # Comment out for older displays
     )
 
     g = displayio.Group()

--- a/README.rst
+++ b/README.rst
@@ -92,7 +92,7 @@ Usage Example
     )
     time.sleep(1)
 
-    # For issues with display not updating top/bottom rows correctly set colstart to 8, 0, or -8    
+    # For issues with display not updating top/bottom rows correctly set colstart to 8, 0, or -8
     display = adafruit_ssd1680.SSD1680(
         display_bus,
         width=250,


### PR DESCRIPTION
Added comment regarding display column start adjustment. This came up once again in the Adafruit forums. While one example on the simple test page has this note, the other two do not and the main page also fails to mention it. So added the same code on examples/ssd1680_simpletest.py to the example code on the main page.

Anyone reviewing this feel free to make any corrections or additional changes you feel will make this issue (ssd1680 vs ssd1680z drive chip) issue more readily apparent. No need to run it past me. 

Thank you.