### PR TITLE
Add SSD1683 4-gray displayio driver and example for 4.2" bare E-Ink Display (#6381)

### DIFF
--- a/adafruit_ssd1680.py
+++ b/adafruit_ssd1680.py
@@ -109,11 +109,11 @@ FPC7519_LUT = (
 
 
 _SSD1683_START_SEQUENCE = (
-    b"\x12\x80\x00\x0a"  # SW_RESET, 10ms delay
+    b"\x12\x80\x00\xc8"  # SW_RESET, 200ms delay (cold-boot: reset/charge-pump settle before LUT load)
     b"\x0c\x00\x04\x8b\x9c\xa4\x0f"  # BOOST_SOFTSTART
     b"\x11\x00\x01\x03"  # RAM data entry mode
     b"\x3c\x00\x01\x03"  # border
-    b"\x21\x00\x02\x00\x00"  # DISP_CTRL1 (4-gray dual-RAM)
+    b"\x21\x00\x02\x00\x00"  # DISP_CTRL1 (no source-line shift; matches adafruit_epd PR #111)
     b"\x3f\x00\x01\x07"  # END_OPTION
     b"\x03\x00\x01\x17"  # gate voltage
     b"\x04\x00\x03\x41\xa8\x32"  # source voltage
@@ -125,238 +125,45 @@ _SSD1683_START_SEQUENCE = (
 
 _SSD1683_DISPLAY_UPDATE_MODE = b"\x22\x00\x01\xcf"  # 4-gray LUT-based update
 
-# 4-gray LUT for GDEY042T81 / FPC-190 (GxEPD2 + ThinkInk verified)
-SSD1683_GRAY4_LUT = bytes(
-    [
-        0x01,
-        0x0A,
-        0x1B,
-        0x0F,
-        0x03,
-        0x01,
-        0x01,
-        0x05,
-        0x0A,
-        0x01,
-        0x0A,
-        0x01,
-        0x01,
-        0x01,
-        0x05,
-        0x08,
-        0x03,
-        0x02,
-        0x04,
-        0x01,
-        0x01,
-        0x01,
-        0x04,
-        0x04,
-        0x02,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x0A,
-        0x1B,
-        0x0F,
-        0x03,
-        0x01,
-        0x01,
-        0x05,
-        0x4A,
-        0x01,
-        0x8A,
-        0x01,
-        0x01,
-        0x01,
-        0x05,
-        0x48,
-        0x03,
-        0x82,
-        0x84,
-        0x01,
-        0x01,
-        0x01,
-        0x84,
-        0x84,
-        0x82,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x0A,
-        0x1B,
-        0x8F,
-        0x03,
-        0x01,
-        0x01,
-        0x05,
-        0x4A,
-        0x01,
-        0x8A,
-        0x01,
-        0x01,
-        0x01,
-        0x05,
-        0x48,
-        0x83,
-        0x82,
-        0x04,
-        0x01,
-        0x01,
-        0x01,
-        0x04,
-        0x04,
-        0x02,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x8A,
-        0x1B,
-        0x8F,
-        0x03,
-        0x01,
-        0x01,
-        0x05,
-        0x4A,
-        0x01,
-        0x8A,
-        0x01,
-        0x01,
-        0x01,
-        0x05,
-        0x48,
-        0x83,
-        0x02,
-        0x04,
-        0x01,
-        0x01,
-        0x01,
-        0x04,
-        0x04,
-        0x02,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x8A,
-        0x9B,
-        0x8F,
-        0x03,
-        0x01,
-        0x01,
-        0x05,
-        0x4A,
-        0x01,
-        0x8A,
-        0x01,
-        0x01,
-        0x01,
-        0x05,
-        0x48,
-        0x03,
-        0x42,
-        0x04,
-        0x01,
-        0x01,
-        0x01,
-        0x04,
-        0x04,
-        0x42,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x01,
-        0x01,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x00,
-        0x02,
-        0x00,
-        0x00,
-    ]
-)  # 227 bytes — GDEY042T81 / FPC-190
+# 4-gray waveform LUT for GDEY042T81 / FPC-190 — native GxEPD2 order (unswapped).
+# Correct level order relies on the BW/Color RAM banks being swapped in __init__
+# (write_black_ram_command=0x26, write_color_ram_command=0x24).
+SSD1683_GRAY4_LUT = bytes.fromhex(
+    # 5 waveform groups x 6 phase-rows (7 B each); GxEPD2 GDEY042T81 lut_4G[0:210]
+    "010A1B0F030101"  # group 0
+    "050A010A010101"
+    "05080302040101"
+    "01040402000101"
+    "01000000000101"
+    "01000000000101"
+    "010A1B0F030101"  # group 1
+    "054A018A010101"
+    "05480382840101"
+    "01848482000101"
+    "01000000000101"
+    "01000000000101"
+    "010A1B8F030101"  # group 2
+    "054A018A010101"
+    "05488382040101"
+    "01040402000101"
+    "01000000000101"
+    "01000000000101"
+    "018A1B8F030101"  # group 3
+    "054A018A010101"
+    "05488302040101"
+    "01040402000101"
+    "01000000000101"
+    "01000000000101"
+    "018A9B8F030101"  # group 4
+    "054A018A010101"
+    "05480342040101"
+    "01040442000101"
+    "01000000000101"
+    "01000000000101"
+    "00000000000000"  # 2 reserved phase-rows
+    "00000000000000"
+    "020000"  # frame-rate / repeat tail
+)  # 227 bytes — GDEY042T81 / FPC-190 (matches Adafruit_EPD ssd1683.py)
 
 
 def detect_ssd1680_panel(data_pin, clk_pin, cs_pin, dc_pin, rst_pin):
@@ -512,11 +319,17 @@ class SSD1683(EPaperDisplay):
     """
 
     def __init__(self, bus: FourWire, vcom: int = 0x30, custom_lut: bytes = b"", **kwargs) -> None:
+        kwargs["grayscale"] = True  # SSD1683 always runs in 4-gray mode
         if "colstart" not in kwargs:
             kwargs["colstart"] = 0
         stop_sequence = bytearray(_STOP_SEQUENCE)
         try:
             bus.reset()
+            # Cold-boot settle: after a true power-on, the controller's regulators
+            # need time before the start sequence loads the LUT (mirrors the
+            # framebuffer driver's sleep(0.1)+busy_wait). A short delay here plus the
+            # longer SW_RESET delay below prevents a corrupt-LUT speckle on cold boot.
+            time.sleep(0.2)
         except RuntimeError:
             stop_sequence = b""
         load_lut = b""
@@ -529,22 +342,23 @@ class SSD1683(EPaperDisplay):
 
         width = kwargs["width"]
         height = kwargs["height"]
+        # Save gate count before any rotation swap — always the physical height (300)
+        gate_height = height
         if "rotation" in kwargs and kwargs["rotation"] % 180 != 90:
             width, height = height, width
-        # SSD1683 4.2" panel: gate lines run along the height dimension
-        start_sequence[54] = (height - 1) & 0xFF
-        start_sequence[55] = ((height - 1) >> 8) & 0xFF
+        start_sequence[54] = (gate_height - 1) & 0xFF
+        start_sequence[55] = ((gate_height - 1) >> 8) & 0xFF
 
         super().__init__(
             bus,
             start_sequence,
             stop_sequence,
             **kwargs,
-            ram_width=400,
+            ram_width=255,  # <256 forces 1-byte X (0x44) addressing; SSD168x X is byte-addressed
             ram_height=300,
             busy_state=True,
-            write_black_ram_command=0x24,
-            write_color_ram_command=0x26,
+            write_black_ram_command=0x26,  # swapped vs SSD1680: displayio packs luma
+            write_color_ram_command=0x24,  # bit7->black,bit6->color; SSD1683 wants the opposite
             set_column_window_command=0x44,
             set_row_window_command=0x45,
             set_current_column_command=0x4E,

--- a/adafruit_ssd1680.py
+++ b/adafruit_ssd1680.py
@@ -109,7 +109,7 @@ FPC7519_LUT = (
 
 
 _SSD1683_START_SEQUENCE = (
-    b"\x12\x80\x00\xc8"  # SW_RESET, 200ms delay (cold-boot: reset/charge-pump settle before LUT load)
+    b"\x12\x80\x00\xc8"  # SW_RESET + 200ms delay (cold-boot charge-pump settle)
     b"\x0c\x00\x04\x8b\x9c\xa4\x0f"  # BOOST_SOFTSTART
     b"\x11\x00\x01\x03"  # RAM data entry mode
     b"\x3c\x00\x01\x03"  # border

--- a/adafruit_ssd1680.py
+++ b/adafruit_ssd1680.py
@@ -108,6 +108,257 @@ FPC7519_LUT = (
 )
 
 
+_SSD1683_START_SEQUENCE = (
+    b"\x12\x80\x00\x0a"  # SW_RESET, 10ms delay
+    b"\x0c\x00\x04\x8b\x9c\xa4\x0f"  # BOOST_SOFTSTART
+    b"\x11\x00\x01\x03"  # RAM data entry mode
+    b"\x3c\x00\x01\x03"  # border
+    b"\x21\x00\x02\x00\x00"  # DISP_CTRL1 (4-gray dual-RAM)
+    b"\x3f\x00\x01\x07"  # END_OPTION
+    b"\x03\x00\x01\x17"  # gate voltage
+    b"\x04\x00\x03\x41\xa8\x32"  # source voltage
+    b"\x2c\x00\x01\x30"  # VCOM (default 0x30, offset 41)
+    b"\x4e\x00\x01\x00"  # RAM X count
+    b"\x4f\x00\x02\x00\x00"  # RAM Y count
+    b"\x01\x00\x03\x00\x00\x00"  # driver output control (gate lo/hi at offsets 54/55)
+)
+
+_SSD1683_DISPLAY_UPDATE_MODE = b"\x22\x00\x01\xcf"  # 4-gray LUT-based update
+
+# 4-gray LUT for GDEY042T81 / FPC-190 (GxEPD2 + ThinkInk verified)
+SSD1683_GRAY4_LUT = bytes(
+    [
+        0x01,
+        0x0A,
+        0x1B,
+        0x0F,
+        0x03,
+        0x01,
+        0x01,
+        0x05,
+        0x0A,
+        0x01,
+        0x0A,
+        0x01,
+        0x01,
+        0x01,
+        0x05,
+        0x08,
+        0x03,
+        0x02,
+        0x04,
+        0x01,
+        0x01,
+        0x01,
+        0x04,
+        0x04,
+        0x02,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x0A,
+        0x1B,
+        0x0F,
+        0x03,
+        0x01,
+        0x01,
+        0x05,
+        0x4A,
+        0x01,
+        0x8A,
+        0x01,
+        0x01,
+        0x01,
+        0x05,
+        0x48,
+        0x03,
+        0x82,
+        0x84,
+        0x01,
+        0x01,
+        0x01,
+        0x84,
+        0x84,
+        0x82,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x0A,
+        0x1B,
+        0x8F,
+        0x03,
+        0x01,
+        0x01,
+        0x05,
+        0x4A,
+        0x01,
+        0x8A,
+        0x01,
+        0x01,
+        0x01,
+        0x05,
+        0x48,
+        0x83,
+        0x82,
+        0x04,
+        0x01,
+        0x01,
+        0x01,
+        0x04,
+        0x04,
+        0x02,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x8A,
+        0x1B,
+        0x8F,
+        0x03,
+        0x01,
+        0x01,
+        0x05,
+        0x4A,
+        0x01,
+        0x8A,
+        0x01,
+        0x01,
+        0x01,
+        0x05,
+        0x48,
+        0x83,
+        0x02,
+        0x04,
+        0x01,
+        0x01,
+        0x01,
+        0x04,
+        0x04,
+        0x02,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x8A,
+        0x9B,
+        0x8F,
+        0x03,
+        0x01,
+        0x01,
+        0x05,
+        0x4A,
+        0x01,
+        0x8A,
+        0x01,
+        0x01,
+        0x01,
+        0x05,
+        0x48,
+        0x03,
+        0x42,
+        0x04,
+        0x01,
+        0x01,
+        0x01,
+        0x04,
+        0x04,
+        0x42,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x01,
+        0x01,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x00,
+        0x02,
+        0x00,
+        0x00,
+    ]
+)  # 227 bytes — GDEY042T81 / FPC-190
+
+
 def detect_ssd1680_panel(data_pin, clk_pin, cs_pin, dc_pin, rst_pin):
     """Read SSD1680 User ID (register 0x2E) via half-duplex bitbang SPI.
 
@@ -221,6 +472,76 @@ class SSD1680(EPaperDisplay):
             **kwargs,
             ram_width=250,
             ram_height=296,
+            busy_state=True,
+            write_black_ram_command=0x24,
+            write_color_ram_command=0x26,
+            set_column_window_command=0x44,
+            set_row_window_command=0x45,
+            set_current_column_command=0x4E,
+            set_current_row_command=0x4F,
+            refresh_display_command=0x20,
+            always_toggle_chip_select=False,
+            address_little_endian=True,
+            two_byte_sequence_length=True,
+        )
+
+
+# pylint: disable=too-few-public-methods
+class SSD1683(EPaperDisplay):
+    r"""SSD1683 driver for 4-gray grayscale e-paper displays.
+
+    Designed for the 4.2" 400×300 GDEY042T81 panel (#6381, FPC-190 ribbon).
+    Gate lines run along the height dimension (300), so DRIVER_CONTROL is set
+    from height rather than width.
+
+    :param bus: The data bus the display is on
+    :param \**kwargs:
+        See below
+
+    :Keyword Arguments:
+        * *width* (``int``) --
+          Display width (400 for the 4.2" panel)
+        * *height* (``int``) --
+          Display height (300 for the 4.2" panel)
+        * *rotation* (``int``) --
+          Display rotation
+        * *vcom* (``int``) --
+          VCOM voltage register value (default 0x30)
+        * *custom_lut* (``bytes``) --
+          Custom waveform LUT; pass ``SSD1683_GRAY4_LUT`` for 4-gray mode
+    """
+
+    def __init__(self, bus: FourWire, vcom: int = 0x30, custom_lut: bytes = b"", **kwargs) -> None:
+        if "colstart" not in kwargs:
+            kwargs["colstart"] = 0
+        stop_sequence = bytearray(_STOP_SEQUENCE)
+        try:
+            bus.reset()
+        except RuntimeError:
+            stop_sequence = b""
+        load_lut = b""
+        display_update_mode = bytearray(_SSD1683_DISPLAY_UPDATE_MODE)
+        if custom_lut:
+            load_lut = b"\x32" + len(custom_lut).to_bytes(2) + custom_lut
+
+        start_sequence = bytearray(_SSD1683_START_SEQUENCE + load_lut + display_update_mode)
+        start_sequence[41] = vcom
+
+        width = kwargs["width"]
+        height = kwargs["height"]
+        if "rotation" in kwargs and kwargs["rotation"] % 180 != 90:
+            width, height = height, width
+        # SSD1683 4.2" panel: gate lines run along the height dimension
+        start_sequence[54] = (height - 1) & 0xFF
+        start_sequence[55] = ((height - 1) >> 8) & 0xFF
+
+        super().__init__(
+            bus,
+            start_sequence,
+            stop_sequence,
+            **kwargs,
+            ram_width=400,
+            ram_height=300,
             busy_state=True,
             write_black_ram_command=0x24,
             write_color_ram_command=0x26,

--- a/adafruit_ssd1680.py
+++ b/adafruit_ssd1680.py
@@ -113,7 +113,7 @@ _SSD1683_START_SEQUENCE = (
     b"\x0c\x00\x04\x8b\x9c\xa4\x0f"  # BOOST_SOFTSTART
     b"\x11\x00\x01\x03"  # RAM data entry mode
     b"\x3c\x00\x01\x03"  # border
-    b"\x21\x00\x02\x00\x00"  # DISP_CTRL1 (no source-line shift; matches adafruit_epd PR #111)
+    b"\x21\x00\x02\x00\x00"  # DISP_CTRL1 (no source-line shift)
     b"\x3f\x00\x01\x07"  # END_OPTION
     b"\x03\x00\x01\x17"  # gate voltage
     b"\x04\x00\x03\x41\xa8\x32"  # source voltage

--- a/examples/ssd1683_4.2_grayscale_6381.py
+++ b/examples/ssd1683_4.2_grayscale_6381.py
@@ -1,0 +1,67 @@
+# SPDX-FileCopyrightText: 2026 Mikey Sklar, written for Adafruit Industries
+#
+# SPDX-License-Identifier: Unlicense
+
+"""4-gray grayscale example for the Adafruit 4.2" 400x300 E-Ink Display (#6381).
+
+Ribbon Identifier: FPC-190, colstart=0.
+Tested on Adafruit Feather RP2040 ThinkInk.
+"""
+
+import time
+
+import board
+import busio
+import displayio
+from fourwire import FourWire
+
+import adafruit_ssd1680
+
+displayio.release_displays()
+
+spi = busio.SPI(board.EPD_SCK, board.EPD_MOSI)
+display_bus = FourWire(
+    spi,
+    command=board.EPD_DC,
+    chip_select=board.EPD_CS,
+    reset=board.EPD_RESET,
+    baudrate=1000000,
+)
+time.sleep(1)
+
+display = adafruit_ssd1680.SSD1683(
+    display_bus,
+    width=400,
+    height=300,
+    busy_pin=board.EPD_BUSY,
+    rotation=270,
+    colstart=0,
+    vcom=0x30,
+    custom_lut=adafruit_ssd1680.SSD1683_GRAY4_LUT,
+)
+
+W, H = 400, 300
+bmp = displayio.Bitmap(W, H, 4)
+pal = displayio.Palette(4)
+pal[0] = 0xFFFFFF  # white
+pal[1] = 0xAAAAAA  # light gray
+pal[2] = 0x555555  # dark gray
+pal[3] = 0x000000  # black
+
+COL = W // 4
+for y in range(H):
+    for x in range(W):
+        bmp[x, y] = min(x // COL, 3)
+
+g = displayio.Group()
+g.append(displayio.TileGrid(bmp, pixel_shader=pal))
+display.root_group = g
+
+print("Refreshing...")
+display.refresh()
+print("Done.")
+
+time.sleep(display.time_to_refresh + 5)
+
+while True:
+    time.sleep(10)

--- a/examples/ssd1683_4.2_grayscale_6381.py
+++ b/examples/ssd1683_4.2_grayscale_6381.py
@@ -2,10 +2,11 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-"""4-gray grayscale example for the Adafruit 4.2" 400x300 E-Ink Display (#6381).
+"""4-gray grayscale info card for the Adafruit 4.2" 400x300 E-Ink Display (#6381).
 
-Ribbon Identifier: FPC-190, colstart=0.
-Tested on Adafruit Feather RP2040 ThinkInk.
+displayio / SSD1683 driver. Layout mirrors the adafruit_epd PR #111 example:
+big built-in font (scale 3-4) and a tall 4-box gray ramp that fills the panel.
+FPC-190 ribbon. Tested on Adafruit Feather RP2040 ThinkInk.
 """
 
 import time
@@ -13,6 +14,8 @@ import time
 import board
 import busio
 import displayio
+import terminalio
+from adafruit_display_text import label
 from fourwire import FourWire
 
 import adafruit_ssd1680
@@ -34,34 +37,68 @@ display = adafruit_ssd1680.SSD1683(
     width=400,
     height=300,
     busy_pin=board.EPD_BUSY,
-    rotation=270,
+    rotation=0,
     colstart=0,
     vcom=0x30,
     custom_lut=adafruit_ssd1680.SSD1683_GRAY4_LUT,
 )
 
 W, H = 400, 300
-bmp = displayio.Bitmap(W, H, 4)
+
+# 4-gray palette (white -> black)
 pal = displayio.Palette(4)
 pal[0] = 0xFFFFFF  # white
 pal[1] = 0xAAAAAA  # light gray
 pal[2] = 0x555555  # dark gray
 pal[3] = 0x000000  # black
-
-COL = W // 4
-for y in range(H):
-    for x in range(W):
-        bmp[x, y] = min(x // COL, 3)
+WHITE, LIGHT, DARK, BLACK = 0, 1, 2, 3
 
 g = displayio.Group()
-g.append(displayio.TileGrid(bmp, pixel_shader=pal))
-display.root_group = g
 
-print("Refreshing...")
+# White background
+bg = displayio.Bitmap(W, H, 4)
+bg.fill(WHITE)
+g.append(displayio.TileGrid(bg, pixel_shader=pal))
+
+# Big text, sized to fill the 400px width (matches PR #111: scale 3-4)
+texts = [
+    ("Adafruit ThinkInk", 6, 10, 3, 0x000000),
+    ('4.2" 400x300', 6, 50, 4, 0x000000),
+    ("4-Gray E-Ink", 6, 95, 4, 0x555555),
+    ("SSD1683  #6381", 6, 140, 3, 0x000000),
+]
+for text, x, y, scale, color in texts:
+    lbl = label.Label(terminalio.FONT, text=text, color=color, scale=scale)
+    lbl.anchor_point = (0.0, 0.0)  # top-left, like framebuf text()
+    lbl.anchored_position = (x, y)
+    g.append(lbl)
+
+# 4-level gray ramp filling the bottom: black | dark | light | white, with borders
+RAMP_TOP = 180
+RAMP_H = H - RAMP_TOP
+SEG = W // 4
+order = (BLACK, DARK, LIGHT, WHITE)  # left -> right
+ramp = displayio.Bitmap(W, RAMP_H, 4)
+for x in range(W):
+    col = order[min(x // SEG, 3)]
+    for y in range(RAMP_H):
+        ramp[x, y] = col
+# black outline + dividers
+for x in range(W):
+    ramp[x, 0] = BLACK
+    ramp[x, RAMP_H - 1] = BLACK
+for y in range(RAMP_H):
+    ramp[0, y] = BLACK
+    ramp[W - 1, y] = BLACK
+    for i in range(1, 4):
+        ramp[i * SEG, y] = BLACK
+g.append(displayio.TileGrid(ramp, pixel_shader=pal, x=0, y=RAMP_TOP))
+
+display.root_group = g
+print("Refreshing 4-gray info card...")
 display.refresh()
 print("Done.")
 
 time.sleep(display.time_to_refresh + 5)
-
 while True:
     time.sleep(10)

--- a/examples/ssd1683_4.2_grayscale_6381.py
+++ b/examples/ssd1683_4.2_grayscale_6381.py
@@ -2,11 +2,10 @@
 #
 # SPDX-License-Identifier: Unlicense
 
-"""4-gray grayscale info card for the Adafruit 4.2" 400x300 E-Ink Display (#6381).
+"""4-gray "ThinkInk" info card for the Adafruit 4.2" 400x300 E-Ink Display (#6381).
 
-displayio / SSD1683 driver. Layout mirrors the adafruit_epd PR #111 example:
-big built-in font (scale 3-4) and a tall 4-box gray ramp that fills the panel.
-FPC-190 ribbon. Tested on Adafruit Feather RP2040 ThinkInk.
+A grayscale take on the factory demo: product text plus a 4-level gray ramp
+(white / light / dark / black) that shows all four shades at once.
 """
 
 import time
@@ -60,7 +59,7 @@ bg = displayio.Bitmap(W, H, 4)
 bg.fill(WHITE)
 g.append(displayio.TileGrid(bg, pixel_shader=pal))
 
-# Big text, sized to fill the 400px width (matches PR #111: scale 3-4)
+# Big text, sized to fill the 400px width
 texts = [
     ("Adafruit ThinkInk", 6, 10, 3, 0x000000),
     ('4.2" 400x300', 6, 50, 4, 0x000000),


### PR DESCRIPTION
Adds `SSD1683` class and `SSD1683_GRAY4_LUT` to `adafruit_ssd1680.py` for the [4.2" bare E-Ink Display (#6381)](https://www.adafruit.com/product/6381) — 400×300 GDEY042T81 panel with SSD1683 controller (FPC-190 ribbon), colstart=0.

## Testing

Feather RP2040 ThinkInk direct-connect